### PR TITLE
Improve person detection reliability

### DIFF
--- a/RealStereo/Camera.cs
+++ b/RealStereo/Camera.cs
@@ -28,7 +28,7 @@ namespace RealStereo
 
             // resize image for more performant detection
             frame = rawFrame.ToImage<Bgr, byte>();
-            double ratio = 400.0 / frame.Width;
+            double ratio = 500.0 / frame.Width;
             frame = frame.Resize((int) (frame.Width * ratio), (int) (frame.Height * ratio), Inter.Cubic);
 
             // detect people

--- a/RealStereo/PeopleDetector.cs
+++ b/RealStereo/PeopleDetector.cs
@@ -10,6 +10,7 @@ namespace RealStereo
     class PeopleDetector
     {
         private HOGDescriptor hogDescriptor;
+        private static int GROUP_THRESHOLD = 50;
 
         public PeopleDetector()
         {
@@ -19,7 +20,7 @@ namespace RealStereo
 
         public MCvObjectDetection[] Detect(Image<Bgr, byte> frame)
         {
-            return hogDescriptor.DetectMultiScale(frame, 0, new Size(4, 4), new Size(8, 8));
+            return hogDescriptor.DetectMultiScale(frame, 0, new Size(2, 2), new Size(8, 8));
         }
 
         public MCvObjectDetection[] Normalize(MCvObjectDetection[] regions)
@@ -37,8 +38,10 @@ namespace RealStereo
                 bool intersects = false;
                 for (int i = 0; i < results.Count; i++)
                 {
+                    // enlarge rect to group close ones
                     MCvObjectDetection result = results[i];
-                    if (region.Rect.IntersectsWith(result.Rect))
+                    Rectangle enlargedResult = new Rectangle(result.Rect.X - GROUP_THRESHOLD, result.Rect.Y - GROUP_THRESHOLD, result.Rect.Width + GROUP_THRESHOLD * 2, result.Rect.Height + GROUP_THRESHOLD * 2);
+                    if (region.Rect.IntersectsWith(enlargedResult))
                     {
                         intersects = true;
                         int maxRight = Math.Max(result.Rect.Right, region.Rect.Right);


### PR DESCRIPTION
Those changes make it more reliable to detect people in the camera feed. The drawback is that it takes slightly more time to process, but I think it is worth it.

Also, close regions will now be grouped into one. For example when two arms get detected but not the full body as a whole -> instead of treating them as two people, they are now combined into one.