### PR TITLE
Fix crash caused by having two cameras with the same name

### DIFF
--- a/RealStereo/MainWindow.xaml.cs
+++ b/RealStereo/MainWindow.xaml.cs
@@ -40,9 +40,19 @@ namespace RealStereo
             videoDevices = new FilterInfoCollection(FilterCategory.VideoInputDevice);
             for (int i = 0; i < videoDevices.Count; i++)
             {
-                videoDeviceNameIndexDictionary.Add(videoDevices[i].Name, i);
-                camera1ComboBox.Items.Add(new string(videoDevices[i].Name));
-                camera2ComboBox.Items.Add(new string(videoDevices[i].Name));
+                String deviceName = videoDevices[i].Name;
+                String initialDeviceName = deviceName;
+                int deviceNumber = 1;
+
+                while (videoDeviceNameIndexDictionary.ContainsKey(deviceName))
+                {
+                    deviceNumber++;
+                    deviceName = initialDeviceName + " " + deviceNumber;
+                }
+
+                videoDeviceNameIndexDictionary.Add(deviceName, i);
+                camera1ComboBox.Items.Add(new string(deviceName));
+                camera2ComboBox.Items.Add(new string(deviceName));
             }
         }
 


### PR DESCRIPTION
I now tested the app on a real windows (not within a VM as previously) and it appears that windows returns the same name for the two logitech webcams which threw an exception because the same key was added twice to the dictionary.