### PR TITLE
Added mapping for channels

### DIFF
--- a/RealStereo/AudioChannelMap.cs
+++ b/RealStereo/AudioChannelMap.cs
@@ -1,0 +1,21 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace RealStereo
+{
+    class AudioChannelMap
+    {
+        public static Dictionary<int, string> Map = new Dictionary<int, string>
+        {
+            { 0, "Left" },
+            { 1, "Right" },
+            { 2, "Center" },
+            { 3, "Sub" },
+            { 4, "Rear Left" },
+            { 5, "Rear Right" },
+            { 6, "Surround Left" },
+            { 7, "Surround Right" },
+        };
+    }
+}

--- a/RealStereo/MainWindow.xaml.cs
+++ b/RealStereo/MainWindow.xaml.cs
@@ -119,7 +119,13 @@ namespace RealStereo
                 for (int channelIndex = 0; channelIndex < audioOut.AudioEndpointVolume.Channels.Count; channelIndex++)
                 {
                     Label label = new Label();
-                    label.Content = "Channel " + (channelIndex + 1);
+                    if (AudioChannelMap.Map.ContainsKey(channelIndex))
+                    {
+                        label.Content = AudioChannelMap.Map[channelIndex];
+                    } else
+                    {
+                        label.Content = "Channel " + (channelIndex + 1);
+                    }
                     label.Margin = new Thickness(0, channelIndex > 0 ? 5 : 0, 0, 0);
                     channelLevelsPanel.Children.Add(label);
 


### PR DESCRIPTION
This fixes #8.
Didn't find a concrete rule, but all audio devices I could find (USB soundcards, motherboard audio, hdmi screen) followed this rule.
Found an API which could theoretically be used for this: https://docs.microsoft.com/en-us/windows/win32/coreaudio/pkey-audioendpoint-physicalspeakers
However every audio device I could find, didn't have this property set.