### PR TITLE
Fix wrong sample conversion & average

### DIFF
--- a/RealStereo/ConfigurationManager.cs
+++ b/RealStereo/ConfigurationManager.cs
@@ -12,8 +12,9 @@ namespace RealStereo
         private Configuration currentConfiguration = new Configuration();
         private TextBlock instructionsText;
         private Border instructionsBox;
+        private ProgressBar audioInputDeviceVolume;
 
-        public ConfigurationManager(ref WorkerThread workerThread, TextBlock instructionsText, Border instructionsBox)
+        public ConfigurationManager(ref WorkerThread workerThread, TextBlock instructionsText, Border instructionsBox, ProgressBar audioInputDeviceVolume)
         {
             steps = new ConfigurationStep[] {
                 new ConfigurationStepCamera(this, ref workerThread),
@@ -22,6 +23,7 @@ namespace RealStereo
 
             this.instructionsText = instructionsText;
             this.instructionsBox = instructionsBox;
+            this.audioInputDeviceVolume = audioInputDeviceVolume;
         }
 
         public void Start()
@@ -72,6 +74,11 @@ namespace RealStereo
         {
             instructionsBox.BorderBrush = Brushes.Red;
             instructionsText.Text = text;
+        }
+
+        public void SetAudioInputDeviceVolume(float value)
+        {
+            audioInputDeviceVolume.Value = value;
         }
     }
 }

--- a/RealStereo/ConfigurationStepSpeaker.cs
+++ b/RealStereo/ConfigurationStepSpeaker.cs
@@ -37,10 +37,9 @@ namespace RealStereo
             MuteAllChannels();
 
             testTone = new TestTone(outputAudioDevice, inputAudioDevice);
-            manager.SetInstructions("Calibrating speakers channel " + (int) (speakerStep / 2) + " - Step 1");
+            manager.SetInstructions("Calibrating speakers channel " + (speakerStep / 2) + " - Step 1");
             outputAudioDevice.AudioEndpointVolume.Channels[0].VolumeLevelScalar = originalChannelVolume[0];
             testTone.Play(2, new EventHandler<StoppedEventArgs>(TestToneStopped));
-            // Detect volume for this channel
         }
 
         public void Cancel()
@@ -84,11 +83,13 @@ namespace RealStereo
 
             MuteAllChannels();
             int channelIndex = speakerStep / 2;
-            if (!volumes.ContainsKey((int)(speakerStep - 1) / 2))
+            if (!volumes.ContainsKey((speakerStep - 1) / 2))
             {
-                volumes[(int)(speakerStep - 1) / 2] = new float[2];
+                volumes[(speakerStep - 1) / 2] = new float[2];
             }
-            volumes[(int) (speakerStep-1) / 2][(speakerStep-1) % 2] = testTone.GetAverageCaptureVolume();
+            float volume = testTone.GetAverageCaptureVolume();
+            manager.SetAudioInputDeviceVolume(volume);
+            volumes[(speakerStep-1) / 2][(speakerStep-1) % 2] = volume;
 
             AudioEndpointVolumeChannel audioEndpointVolume = outputAudioDevice.AudioEndpointVolume.Channels[channelIndex];
             if (speakerStep % 2 == 0)

--- a/RealStereo/ConfigurationWindow.xaml
+++ b/RealStereo/ConfigurationWindow.xaml
@@ -5,7 +5,7 @@
         xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
         xmlns:local="clr-namespace:RealStereo"
         mc:Ignorable="d"
-        Title="Configuration" Height="450" Width="400">
+        Title="Configuration" Height="475" Width="400">
     <ScrollViewer VerticalScrollBarVisibility="Auto">
         <DockPanel>
             <StackPanel DockPanel.Dock="Top" Margin="10,10,10,10">
@@ -30,6 +30,7 @@
                 <Border x:Name="instructionsBox" Visibility="Collapsed" BorderBrush="Green" BorderThickness="2" Margin="0,10,0,0">
                     <TextBlock x:Name="instructionsText" TextWrapping="Wrap" Margin="10" TextAlignment="Center" FontSize="20" />
                 </Border>
+                <ProgressBar x:Name="audioInputDeviceVolume" Visibility="Collapsed" Height="10" Maximum="1" Margin="0,5,0,0"/>
 
                 <StackPanel x:Name="positions" Visibility="Collapsed">
                     <Label Content="Calibration progress" Margin="0,10,0,0" />

--- a/RealStereo/ConfigurationWindow.xaml.cs
+++ b/RealStereo/ConfigurationWindow.xaml.cs
@@ -16,7 +16,7 @@ namespace RealStereo
 
         public void InitConfiguration(ref WorkerThread workerThread)
         {
-            manager = new ConfigurationManager(ref workerThread, instructionsText, instructionsBox);
+            manager = new ConfigurationManager(ref workerThread, instructionsText, instructionsBox, audioInputDeviceVolume);
 
             // if all devices are set, enable the start button
             if (workerThread.GetCameras().Keys.Count >= 2 && workerThread.GetOutputAudioDevice() != null && workerThread.GetInputAudioDevice() != null)
@@ -36,6 +36,7 @@ namespace RealStereo
             startCalibrationButton.IsEnabled = false;
             positions.Visibility = Visibility.Visible;
             instructionsBox.Visibility = Visibility.Visible;
+            audioInputDeviceVolume.Visibility = Visibility.Visible;
             manager.Start();
         }
     }

--- a/RealStereo/TestTone.cs
+++ b/RealStereo/TestTone.cs
@@ -4,6 +4,8 @@ using NAudio.Wave.SampleProviders;
 using System;
 using System.Collections.Generic;
 using System.Text;
+using System.Threading;
+using System.Windows;
 
 namespace RealStereo
 {
@@ -13,7 +15,7 @@ namespace RealStereo
         private MMDevice outputAudioDevice, inputAudioDevice;
         private IWavePlayer outWavePlayer;
         private WasapiCapture wasapiCapture;
-        private List<float> captureSamples = new List<float>();
+        private readonly List<float> captureSamples = new List<float>();
 
         public TestTone(MMDevice outputAudioDevice, MMDevice inputAudioDevice)
         {
@@ -33,30 +35,10 @@ namespace RealStereo
             wasapiCapture = new WasapiCapture(inputAudioDevice);
             wasapiCapture.DataAvailable += new EventHandler<WaveInEventArgs>(delegate (object o, WaveInEventArgs e)
             {
-                int increaseBy = (wasapiCapture.WaveFormat.BitsPerSample / 8) * wasapiCapture.WaveFormat.Channels;
-                for (int i = 0; i < e.BytesRecorded; i += increaseBy)
+                for (int i = 0; i < e.BytesRecorded; i += 4)
                 {
-                    float scaledSample = 0;
-                    switch(wasapiCapture.WaveFormat.BitsPerSample)
-                    {
-                        case 32:
-                            uint intSample = (uint)((e.Buffer[i + 3] << 24) | (e.Buffer[i+2] << 16) | (e.Buffer[i+1] << 8) | e.Buffer[i]);
-                            scaledSample = intSample / 4294967295f; /// 2147483648f;
-                            break;
-                        case 24:
-                            uint int24Sample = (uint)((e.Buffer[i + 2] << 16) | (e.Buffer[i + 1] << 8) | e.Buffer[i]);
-                            scaledSample = int24Sample / 16777216f; /// 8388608f;
-                            break;
-                        case 16:
-                            ushort shortSample = (ushort)((e.Buffer[i + 1] << 8) | e.Buffer[i]);
-                            scaledSample = shortSample / 65535f;
-                            break;
-                        case 8:
-                            byte byteSample = (byte)e.Buffer[i];
-                            scaledSample = byteSample / 255f;
-                            break;
-                    }
-                    captureSamples.Add(scaledSample);
+                    float sample = BitConverter.ToSingle(e.Buffer, i);
+                    captureSamples.Add(sample);
                 }
             });
 
@@ -87,17 +69,18 @@ namespace RealStereo
         public float GetAverageCaptureVolume()
         {
             int count = captureSamples.Count;
-            int countZeros = 0;
             float sum = 0;
             for (int i = 0; i < count; i++)
             {
-                if (captureSamples[i] == 0)
+                if (captureSamples[i] < 0)
                 {
-                    countZeros++;
+                    sum -= captureSamples[i];
+                } else
+                {
+                    sum += captureSamples[i];
                 }
-                sum += captureSamples[i];
             }
-            return sum / (count-countZeros);
+            return sum / count;
         }
     }
 }


### PR DESCRIPTION
After taking another look at the documentation and this helpful SO Thread (https://stackoverflow.com/questions/45535659/naudio-wasapi-recording-and-conversion) I realised that most of my previous work was unnecessary, because when using the WASAPI API, the sample format returned is **always** 32bits no matter what the device actually records in. 
This makes the code way less complicated and also fixes the sometimes very strange values I got since I used the devices sample size (16bit in my case) to decode the buffer instead of the 32bit sample size from WASAPI.

Additionally I took another look at the PCM format and came to the conclusion, that simply inverting all negative and calculating an average over that results a very usable volume estimation.
One improvement could be a combination of low & high-pass filter to limit the recording to the 2000hz sine wave we actually emit. This should emit the background noise problem almost entirely.
Additionally we could implement a gain algorithm which, in a separate & additional step at the beginning, plays a sound on all speakers and then amplifies the result to reach high enough levels and then apply that amplification amount to all further test tone recordings. Not sure if this is gonna noticeably improve results or not, just something I noticed while testing.