### PR TITLE
Exit program on window close

### DIFF
--- a/RealStereo/MainWindow.xaml.cs
+++ b/RealStereo/MainWindow.xaml.cs
@@ -315,7 +315,6 @@ namespace RealStereo
         private void OnClosed(object sender, EventArgs e)
         {
             workerThread.Stop();
-            Application.Current.Shutdown();
         }
     }
 }

--- a/RealStereo/WorkerThread.cs
+++ b/RealStereo/WorkerThread.cs
@@ -15,7 +15,6 @@ namespace RealStereo
         private Thread thread;
         private Dictionary<Image, Camera> cameras;
         private bool isBalancing = false;
-        private bool cancelled = false;
         private MMDevice outputAudioDevice;
         private MMDevice inputAudioDevice;
 
@@ -68,8 +67,7 @@ namespace RealStereo
 
         public void Stop()
         {
-            cancelled = true;
-            thread.Join();
+            thread.Interrupt();
         }
 
         protected virtual void OnResultReady(WorkerResult result)
@@ -85,12 +83,17 @@ namespace RealStereo
 
         private void Run()
         {
-            while (!cancelled)
+            try
             {
-                DoWork();
+                while (true)
+                {
+                    DoWork();
 
-                Thread.Sleep(1000 / FPS);
+                    Thread.Sleep(1000 / FPS);
+                }
             }
+            catch (ThreadInterruptedException)
+            {}
         }
 
         private void DoWork()


### PR DESCRIPTION
Resolves #18 

The issue was that the worker thread was still running in the background because the `canceled` variable was set outside of the thread which obviously doesn't work.
I changed it now so an InterruptedException now always cancels the worker thread and so properly exits the program.