### PR TITLE
Fix same recorded volume for all positions

### DIFF
--- a/RealStereo/ConfigurationStepSpeaker.cs
+++ b/RealStereo/ConfigurationStepSpeaker.cs
@@ -86,7 +86,7 @@ namespace RealStereo
                 outputAudioDevice.AudioEndpointVolume.Channels[i].VolumeLevelScalar = originalChannelVolume[i];
             }
 
-            currentConfiguration.Volumes = new Dictionary<int, float[]>(volumes);
+            currentConfiguration.Volumes = volumes;
             return currentConfiguration;
         }
 


### PR DESCRIPTION
Resolves #25 as the same dictionary (and so same reference) was previously used. Now, a new dictionary gets created for each position.