### PR TITLE
Improve interpolation

### DIFF
--- a/RealStereo/ConfigurationStepSpeaker.cs
+++ b/RealStereo/ConfigurationStepSpeaker.cs
@@ -107,7 +107,8 @@ namespace RealStereo
             int channelIndex = speakerStep / 2;
             if (!volumes.ContainsKey((speakerStep - 1) / 2))
             {
-                volumes[(speakerStep - 1) / 2] = new float[2];
+                volumes[(speakerStep - 1) / 2] = new float[3];
+                volumes[(speakerStep - 1) / 2][2] = originalChannelVolume[(speakerStep - 1) / 2];
             }
             float volume = testTone.GetAverageCaptureVolume() * volumeScalingFactor;
             manager.SetAudioInputDeviceVolume(volume);

--- a/RealStereo/PointConfiguration.cs
+++ b/RealStereo/PointConfiguration.cs
@@ -7,6 +7,6 @@ namespace RealStereo
     public class PointConfiguration
     {
         public Point Coordinates;
-        public Dictionary<int, float[]> Volumes; // Float array index 0 contains the recording volume of the 100% audio playback volume, index 1 the 50% audio playback volume
+        public Dictionary<int, float[]> Volumes; // Float array index 0 contains the recording volume of the 100% audio playback volume, index 1 the 50% audio playback volume, index 2 the initial speaker volume
     }
 }

--- a/RealStereo/VolumeInterpolationDebugWindow.xaml.cs
+++ b/RealStereo/VolumeInterpolationDebugWindow.xaml.cs
@@ -40,7 +40,7 @@ namespace RealStereo
                     Rectangle rect = new Rectangle();
                     rect.Width = scale;
                     rect.Height = scale;
-                    byte intensity = (byte)(255 - (255 / (minMax[1] - minMax[0])) * (volumeInterpolation.Values[x, y, speakerIndex] - minMax[0]));
+                    byte intensity = (byte)(255 - (255 / (minMax[1] - minMax[0])) * (volumeInterpolation.Values[x, y, speakerIndex, 0] - minMax[0]));
                     rect.Fill = new SolidColorBrush(Color.FromRgb(intensity, intensity, 255));
 
                     canvas.Children.Add(rect);
@@ -58,7 +58,7 @@ namespace RealStereo
             {
                 for (int y = 0; y < volumeInterpolation.Values.GetLength(1); y++)
                 {
-                    double value = volumeInterpolation.Values[x, y, speakerIndex];
+                    double value = volumeInterpolation.Values[x, y, speakerIndex, 0];
 
                     if (value < minMax[0])
                     {


### PR DESCRIPTION
This improves the interpolation by calculating a second value: expected difference by 1% speaker volume change.

It now also stores the initial speaker volumes in the configuration file, so there may be errors if an old configuration without this information gets used.

The interpolation result is now stored in a 4 dimesional array: `[x, y, speakerIndex, value]` where `value` is a two dimensional array containing both interpolation values: `[interpolatedVolume, interpolatedDifferenceBy1PercentChange]`

With this information, I think we can calculate the speaker volumes something like this per speaker:

```
volumeDifference = targetVolume - interpolatedVolume[x, y, speaker, 0]
volume[speaker] = initialSpeakerVolume[speaker] - (volumeDifference / interpolatedVolume[x, y, speaker, 1])
```

Does this make sense?

The only remaining thing is to decide what our target volume is. The maximum recorded value across all speakers? Or the average (`(max - min) / 2`) recorded volume?