### PR TITLE
Fix crashes during volume calculation

### DIFF
--- a/RealStereo/VolumeInterpolation.cs
+++ b/RealStereo/VolumeInterpolation.cs
@@ -102,7 +102,8 @@ namespace RealStereo
             int mapped_x = MapCoordinate(x);
             int mapped_y = MapCoordinate(y);
             double volumeDifference = targetVolume - Values[mapped_x, mapped_y, speakerIndex, 0];
-            return points[0].Volumes[speakerIndex][2] - (volumeDifference / Values[mapped_x, mapped_y, speakerIndex, 1]);
+            double volume = points[0].Volumes[speakerIndex][2] - (volumeDifference / Values[mapped_x, mapped_y, speakerIndex, 1]) / 100;
+            return Math.Max(Math.Min(volume, 1.0), 0.0);
         } 
     }
 }

--- a/RealStereo/WorkerThread.cs
+++ b/RealStereo/WorkerThread.cs
@@ -148,13 +148,13 @@ namespace RealStereo
             if (applyCoordinates)
             {
                 result.SetCoordinates(coordinates);
-            }
 
-            if (isBalancing)
-            {
-                for (int i = 0; i < outputAudioDevice.AudioEndpointVolume.Channels.Count; i++)
+                if (isBalancing)
                 {
-                    outputAudioDevice.AudioEndpointVolume.Channels[i].VolumeLevelScalar = (float)volumeInterpolation.GetVolumeForPositionAndSpeaker(coordinates.X, coordinates.Y, i);
+                    for (int i = 0; i < outputAudioDevice.AudioEndpointVolume.Channels.Count; i++)
+                    {
+                        outputAudioDevice.AudioEndpointVolume.Channels[i].VolumeLevelScalar = (float)volumeInterpolation.GetVolumeForPositionAndSpeaker(coordinates.X, coordinates.Y, i);
+                    }
                 }
             }
 


### PR DESCRIPTION
Running the calculation crashed because some invalid volume was set (< 0 or > 1).

I've made the following changes:
- Limit volume to 0-1 (for those weird "empty" channels parallels adds)
- Only set it when the camera detected a person
- /100 as 1 percent is 0.01 and not 1 (was the main error for the crash, didn't think about it previously)

At least it doesn't crash anymore, but I couldn't really test it yet as I now have another group project to work on.