### PR TITLE
Fix crash when trying to access a webcam which isn't ready (closed laptop for example)

### DIFF
--- a/RealStereo/Camera.cs
+++ b/RealStereo/Camera.cs
@@ -27,6 +27,10 @@ namespace RealStereo
         public void Process(bool detectPeople)
         {
             Mat rawFrame = capture.QueryFrame();
+            if (rawFrame == null)
+            {
+                return;
+            }
 
             // resize image for more performant detection
             frame = rawFrame.ToImage<Bgr, byte>();


### PR DESCRIPTION
This fixes an issue where the program would crash if selecting a webcam which wasn't ready for capture. For example selecting the built-in webcam of a MacBook while the lid is closed.

This was found while trying to find a solution for the green webcam issue I've been facing.
Turns out the webcam works perfectly in the built-in `Camera` App/Program of Windows 10 but not in our app. Tried some things I found with google but I can't find the culprit for this weird behaviour. It may be that my webcam is somehow behaving weirdly but this is made even weirder by the fact that this only started appearing after the Big Sur update.